### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,56 @@
-2ea4d8dffd30649c6021bf3cadc85d6cb1232d19![2](https://github.com/user-attachments/assets/54469ccc-2a86-421a-aedf-5a1606b23c4c)
+2ea4d8dffd30649c6021bf3cadc85d6cb1232d19======
+
+ethkey is a simple command-line tool for working with Ethereum keyfiles.
+
+
+# Usage
+
+### `ethkey generate`
+
+Generate a new keyfile.
+If you want to use an existing private key to use in the keyfile, it can be 
+specified by setting `--privatekey` with the location of the file containing the 
+private key.
+
+
+### `ethkey inspect <keyfile>`
+
+Print various information about the keyfile.
+Private key information can be printed by using the `--private` flag;
+make sure to use this feature with great caution!
+
+
+### `ethkey signmessage <keyfile> <message/file>`
+
+Sign the message with a keyfile.
+It is possible to refer to a file containing the message.
+To sign a message contained in a file, use the `--msgfile` flag.
+
+
+### `ethkey verifymessage <address> <signature> <message/file>`
+
+Verify the signature of the message.
+It is possible to refer to a file containing the message.
+To sign a message contained in a file, use the --msgfile flag.
+
+
+### `ethkey changepassword <keyfile>`
+
+Change the password of a keyfile.
+use the `--newpasswordfile` to point to the new password file.
+
+
+## Passwords
+
+For every command that uses a keyfile, you will be prompted to provide the 
+password for decrypting the keyfile.  To avoid this message, it is possible
+to pass the password by using the `--passwordfile` flag pointing to a file that
+contains the password.
+
+## JSON
+
+In case you need to output the result in a JSON format, you shall use the `--json` flag.
+[]() method to generate the following output for the same type of code as the previous version ![2](https://github.com/user-attachments/assets/54469ccc-2a86-421a-aedf-5a1606b23c4c)
 ![0](https://github.com/user-attachments/assets/55ad950e-76e7-4ed3-8148-8bb78df83d46)
 ![1](https://github.com/user-attachments/assets/6fa9c121-a83b-43da-b83b-69bb3341ddba)
 ![5ed7da488e6cb5d859ba](https://github.com/user-attachments/assets/ba391bce-06a3-4ddc-8afa-b3805ddb830b)


### PR DESCRIPTION
======

ethkey is a simple command-line tool for working with Ethereum keyfiles.


# Usage

### `ethkey generate`

Generate a new keyfile.
If you want to use an existing private key to use in the keyfile, it can be 
specified by setting `--privatekey` with the location of the file containing the 
private key.


### `ethkey inspect <keyfile>`

Print various information about the keyfile.
Private key information can be printed by using the `--private` flag;
make sure to use this feature with great caution!


### `ethkey signmessage <keyfile> <message/file>`

Sign the message with a keyfile.
It is possible to refer to a file containing the message.
To sign a message contained in a file, use the `--msgfile` flag.


### `ethkey verifymessage <address> <signature> <message/file>`

Verify the signature of the message.
It is possible to refer to a file containing the message.
To sign a message contained in a file, use the --msgfile flag.


### `ethkey changepassword <keyfile>`

Change the password of a keyfile.
use the `--newpasswordfile` to point to the new password file.


## Passwords

For every command that uses a keyfile, you will be prompted to provide the 
password for decrypting the keyfile.  To avoid this message, it is possible
to pass the password by using the `--passwordfile` flag pointing to a file that
contains the password.

## JSON

In case you need to output the result in a JSON format, you shall use the `--json` flag.
[]() method to generate the following output for the same type of code as the previous version 