### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,58 @@
-2ea4d8dffd30649c6021bf3cadc85d6cb1232d19======
+# 🌈✨Rainbow Scientist's Playground Organization✨🌈
 
-ethkey is a simple command-line tool for working with Ethereum keyfiles.
+🙋‍♀️ Welcome to the #🌈✨Rainbow Scientist's Playground Organization✨🌈
 
+✨ Our mission is to showcase and demonstrate the best that GitHub has to offer. We focus on creating repositories that highlight various features and best practices for effective code management 👨🏽‍💼 and collaboration 🫂.
 
-# Usage
+## 🍿 Featured Repository
 
-### `ethkey generate`
+The Demo Repository is a collection of projects and code samples available on GitHub under the 🌈✨Rainbow Scientist's Playground✨🌈 organization. It includes various repositories such as:
+- 🦄 Implementations of nodes for the Polygon zkEVM Network
+- 🔷 Ethereum wallet applications
+- ⛓️‍💥 Blockchain-related code
 
-Generate a new keyfile.
-If you want to use an existing private key to use in the keyfile, it can be 
-specified by setting `--privatekey` with the location of the file containing the 
-private key.
+For more details, you can visit the 🌈✨Rainbow Scientist's Playground Organization✨🌈 on GitHub.
 
+## Repository Contents
 
-### `ethkey inspect <keyfile>`
+This repository demonstrates GitHub's capabilities with minimal noise. It includes:
+- An `index.html` file crucial for rendering a webpage
+- 2️⃣ GitHub Actions workflows
+- 🎼 CSS stylesheet dependency
 
-Print various information about the keyfile.
-Private key information can be printed by using the `--private` flag;
-make sure to use this feature with great caution!
+## 👩‍💻 Contributing
 
+If you're eager to contribute, we're open to everyone's input. Here’s how you can get started:
+1. 🔃 Fork the repository
+2. 🌿 Create a new branch for your feature or bug fix
+3. 📝 Submit a pull request with a clear description of your changes
 
-### `ethkey signmessage <keyfile> <message/file>`
+## 🪪 License
 
-Sign the message with a keyfile.
-It is possible to refer to a file containing the message.
-To sign a message contained in a file, use the `--msgfile` flag.
+This organization and its repositories are licensed under Creative Commons Attribution 4.0 International License.
 
+## 💡 Getting Started
 
-### `ethkey verifymessage <address> <signature> <message/file>`
+Here are some ideas to get you started:
+- 🙋‍♀️ A short introduction - what is your organization all about?
+- 🌈 Contribution guidelines - how can the community get involved?
+- 👩‍💻 Useful resources - where can the community find your docs? Is there anything else the community should know?
+- 🍿 Fun facts - what does your team eat for breakfast?
 
-Verify the signature of the message.
-It is possible to refer to a file containing the message.
-To sign a message contained in a file, use the --msgfile flag.
+## 👥 Meet Our Team
 
+We have a diverse and talented team dedicated to making the 🌈✨Rainbow Scientist's Playground✨🌈 a success. Here are some of our key members:
 
-### `ethkey changepassword <keyfile>`
+- **Alice Johnson** - Project Manager 🧑‍💼
+  - Alice ensures that all projects are on track and that our team is working efficiently.
+- **Bob Smith** - Lead Developer 👨‍💻
+  - Bob is the brain behind our code, leading the development of our key projects.
+- **Carol Martinez** - UX/UI Designer 🎨
+  - Carol designs intuitive and beautiful interfaces for our applications.
+- **David Lee** - Blockchain Specialist ⛓️
+  - David brings his expertise in blockchain technology to our projects.
+- **Eve Thompson** - Community Manager 🫂
+  - Eve engages with our community and ensures that everyone feels welcome and valued.
 
-Change the password of a keyfile.
-use the `--newpasswordfile` to point to the new password file.
-
-
-## Passwords
-
-For every command that uses a keyfile, you will be prompted to provide the 
-password for decrypting the keyfile.  To avoid this message, it is possible
-to pass the password by using the `--passwordfile` flag pointing to a file that
-contains the password.
-
-## JSON
-
-In case you need to output the result in a JSON format, you shall use the `--json` flag.
-[]() method to generate the following output for the same type of code as the previous version ![2](https://github.com/user-attachments/assets/54469ccc-2a86-421a-aedf-5a1606b23c4c)
-![0](https://github.com/user-attachments/assets/55ad950e-76e7-4ed3-8148-8bb78df83d46)
-![1](https://github.com/user-attachments/assets/6fa9c121-a83b-43da-b83b-69bb3341ddba)
-![5ed7da488e6cb5d859ba](https://github.com/user-attachments/assets/ba391bce-06a3-4ddc-8afa-b3805ddb830b)
+🧙 Remember, you can do mighty things with the power of [Markdown](https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
+```


### PR DESCRIPTION
Adding Organization Members to a Team:
People with owner or team maintainer permissions can add organization members to teams. In the upper-right corner of GitHub, select your profile photo, then click Your organizations. Click the name of your organization.
Under your organization name, click Teams.
Click the name of the team.
At the top of the team page, click Members.
Above the list of team members, click Add a member. Add an organization member to the team or invite a non-member to join a team by typing their username or email address and clicking Enter. The user will receive an email invitation to join your organization and will be added to the team once they accept the invitation1. Managing Teams and People with Access to Your Repository: Navigate to the main page of the repository.
Under your repository name, click Settings.
In the Access section of the sidebar, click Collaborators & teams. To the right of Manage access, click Add people or Add teams. In the search field, start typing the name of the team or person to invite, then click a name in the list of matches. Under Choose a role, select the repository role to grant to the team or person, then click Add NAME to REPOSITORY2.

## Summary by Sourcery

Update the README.md to provide a comprehensive overview of the Rainbow Scientist's Playground Organization, including its mission, featured repositories, and contribution guidelines.

Documentation:
- Revise the README.md to introduce the Rainbow Scientist's Playground Organization, highlighting its mission and featured repositories.
- Add sections to the README.md detailing repository contents, contribution guidelines, license information, and team members.